### PR TITLE
feat: emit error instead of logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topgg-autoposter",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "description": "Auto-Poster for Top.gg",
   "main": "index.js",
   "scripts": {

--- a/src/structs/BasePoster.ts
+++ b/src/structs/BasePoster.ts
@@ -13,6 +13,7 @@ export interface BasePosterInterface {
 
 export interface BasePoster {
   on(event: 'posted', listener: (stats) => void)
+  on(event: 'error', listener: (Error) => void)
 }
 
 export class BasePoster extends EventEmitter {

--- a/src/structs/BasePoster.ts
+++ b/src/structs/BasePoster.ts
@@ -88,6 +88,6 @@ export class BasePoster extends EventEmitter {
   public async post () {
     this.api.postStats(await this.binds.getStats())
       .then((data) => this.emit('posted', data))
-      .catch((err) => this.emit("error", err))
+      .catch((err) => "error" in this._events ? this.emit("error", err) : console.error(err))
   }
 }

--- a/src/structs/BasePoster.ts
+++ b/src/structs/BasePoster.ts
@@ -88,6 +88,6 @@ export class BasePoster extends EventEmitter {
   public async post () {
     this.api.postStats(await this.binds.getStats())
       .then((data) => this.emit('posted', data))
-      .catch(err => console.error(err))
+      .catch((err) => this.emit("error", err))
   }
 }


### PR DESCRIPTION
Right now, the developers don't have any options ( other than logs ) to know if a post call failed.

# Changes
- `error` event is emitted instead of logging