### PR TITLE
fix: use the correct name for the "clientReady" event

### DIFF
--- a/src/structs/DJSPoster.ts
+++ b/src/structs/DJSPoster.ts
@@ -42,7 +42,7 @@ export class DJSPoster extends BasePoster implements BasePosterInterface {
   }
 
   public waitForReady(fn: () => void) {
-    this.client.once('ready', () => {
+    this.client.once('clientReady', () => {
       fn()
     })
   }


### PR DESCRIPTION
"ready" is deprecated and will be removed in Discord.js 15